### PR TITLE
ref(Lexer, Parser): [#4] Refactor FullStop into an operator

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,12 +14,14 @@ Each step in the rewrite is done in a new `patch` version to ensure clarity of c
 
 - Unit tests suites for parsing and lexing have been moved into their own files in corresponding directories.
 - The associated function `flatten_environment` is now a method.
+- The token `FullStop` has been refactored into `Operator(Operators::Other(OtherOperators::ACCESSOR))` to reduce code duplication.
 
 #### Minor changes
 
 - Changed a test to check for lack of terminators in explicit return environments.
 - Removed `NEWSTRUCTURE.md`.
 - Updated `STRUCTURE.md` and `Basics.md` to match rewrite.
+- Fixed tests to match the refactoring of `FullStop`.
 
 ### Version 0.5.10
 

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -123,7 +123,7 @@ impl Lexer {
                 "+" | "-" | "*" | "/" | "%" | "^" | "=" =>
                     tokens.push(self.tokenize_operator(&unicode_string, pos)?),
                 "." =>
-                    tokens.push(Token::FullStop(OtherOperators::ACCESSOR)),
+                    tokens.push(Token::Operator(Operators::Other(OtherOperators::ACCESSOR))),
                 "," =>
                     tokens.push(Token::Comma),
                 ";" =>

--- a/src/lexer/tests.rs
+++ b/src/lexer/tests.rs
@@ -170,7 +170,7 @@ mod tests {
     fn matches_fullstop() {
         let input = vec![".".to_string()];
         let tokens = Lexer::new(input).tokenize().unwrap();
-        assert_eq!(tokens, vec![Token::FullStop(OtherOperators::ACCESSOR), Token::EOF]);
+        assert_eq!(tokens, vec![Token::Operator(Operators::Other(OtherOperators::ACCESSOR)), Token::EOF]);
     }
 
     #[test]

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -17,7 +17,6 @@ pub enum Token {
     Whitespace(Rc<str>),
     Operator(Operators),
     LineTerminator(ReservedSymbols),
-    FullStop(OtherOperators),
     Comma,
     EOF,
 }
@@ -37,7 +36,6 @@ impl ToString for Token {
             | Token::RightParen(b)
             | Token::LeftBracket(b)
             | Token::RightBracket(b) => b.to_string(),
-            Token::FullStop(fs) => fs.to_string(),
             Token::Whitespace(w) => w.to_string(),
             Token::EOF => "end of file".to_string(),
             Token::LineTerminator(lt) => lt.to_string(),

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -21,7 +21,7 @@ mod tests {
     fn float() {
         let tokens = vec![
             Token::Number("5".into()),
-            Token::FullStop(OtherOperators::ACCESSOR),
+            Token::Operator(Operators::Other(OtherOperators::ACCESSOR)),
             Token::Number("0".into()),
             Token::EOF
         ];
@@ -101,7 +101,7 @@ mod tests {
     fn accession() {
         let tokens = vec![
             Token::Identifier("x".into()),
-            Token::FullStop(OtherOperators::ACCESSOR),
+            Token::Operator(Operators::Other(OtherOperators::ACCESSOR)),
             Token::Identifier("y".into()),
             Token::LineTerminator(ReservedSymbols::TERMINATOR),
             Token::EOF,
@@ -952,9 +952,9 @@ mod tests {
     fn malformed_number() {
         let tokens = vec![
             Token::Number("5".into()),
-            Token::FullStop(OtherOperators::ACCESSOR),
+            Token::Operator(Operators::Other(OtherOperators::ACCESSOR)),
             Token::Number("0".into()),
-            Token::FullStop(OtherOperators::ACCESSOR),
+            Token::Operator(Operators::Other(OtherOperators::ACCESSOR)),
             Token::Number("0".into()),
             Token::EOF
         ];
@@ -979,7 +979,7 @@ mod tests {
     #[test]
     fn cannot_start_with_fullstop() {
         let tokens = vec![
-            Token::FullStop(OtherOperators::ACCESSOR),
+            Token::Operator(Operators::Other(OtherOperators::ACCESSOR)),
             Token::EOF
         ];
         let mut parser = Parser::new(tokens);


### PR DESCRIPTION
Fixes issue #4.

`Token::FullStop` is now refactored into `Token::Operator(Operators::Other(OtherOperators::ACCESSOR))`. Lexer and parser implementations, methods, and tests have been changed appropriately. All tests are passing.