### PR TITLE
Issues 8 and 13: Add unary operator parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,12 @@ This version adds a bunch of operators as well as implements operator precedence
 #### Major changes
 
 - Added the enum variant `AstNode::UnaryOp` as a struct with two fields: the `op` operator and the `operand` (RHS of the operation).
-- The parser now recognises and parses the unary arithmetic operators `-` and `+`. Their priority is above binary operations. The change does not affect the parsing of binary operations.
+- The parser now recognises and parses the unary arithmetic operators `-` and `+` as well as the unary logical operator NOT `!`. Their priority is above binary operations. The change does not affect the parsing of binary operations.
 - EOF token parsing has been changed: EOF tokens are now allowed in all normal-context environments (previously only the global normal-context environment allowed them). This solves issues with parsing unary operations inside binary operations.
 
 #### Minor changes
 
-- Added tests for unary arithmetic operator parsing.
+- Added tests for unary arithmetic and logical operator parsing.
 - Added error variants for failed unary operator parsing.
 
 ### Version 0.6.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This version adds a bunch of operators as well as implements operator precedence
 
 - Added the enum variant `AstNode::UnaryOp` as a struct with two fields: the `op` operator and the `operand` (RHS of the operation).
 - The parser now recognises and parses the unary arithmetic operators `-` and `+`. Their priority is above binary operations. The change does not affect the parsing of binary operations.
+- EOF token parsing has been changed: EOF tokens are now allowed in all normal-context environments (previously only the global normal-context environment allowed them). This solves issues with parsing unary operations inside binary operations.
 
 #### Minor changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This version adds a bunch of operators as well as implements operator precedence
 
 - Added the enum variant `AstNode::UnaryOp` as a struct with two fields: the `op` operator and the `operand` (RHS of the operation).
 - The parser now recognises and parses the unary arithmetic operators `-` and `+` as well as the unary logical operator NOT `!`. Their priority is above binary operations. The change does not affect the parsing of binary operations.
-- EOF token parsing has been changed: EOF tokens are now allowed in all normal-context environments (previously only the global normal-context environment allowed them). This solves issues with parsing unary operations inside binary operations.
+- EOF token parsing has been changed: EOF tokens are now allowed in all normal-context environments (previously only the global normal-context environment allowed them). This solves issues with parsing unary operations inside binary operations. This also affects how the parser reacts to an empty token stream while parsing an environment (which equally now allows the contexts `Normal` and `FunctionReturn`).
 
 #### Minor changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,24 @@ This is the Envlang alpha development version. Expect large API changes and sudd
 
 This version adds a bunch of operators as well as implements operator precedence.
 
+### Version 0.6.2
+
+#### Major changes
+
+- Added the enum variant `AstNode::UnaryOp` as a struct with two fields: the `op` operator and the `operand` (RHS of the operation).
+- The parser now recognises and parses the unary arithmetic operators `-` and `+`. Their priority is above binary operations. The change does not affect the parsing of binary operations.
+
+#### Minor changes
+
+- Added tests for unary arithmetic operator parsing.
+- Added error variants for failed unary operator parsing.
+
 ### Version 0.6.1
 
 #### Major changes
 
 - Added the symbol enum `LogicalOperators`. It enumerates three Boolean-logical operators: AND, OR, and NOT.
-- Added the num variant `Operators::Logical(LogicalOperators)`.
+- Added the enum variant `Operators::Logical(LogicalOperators)`.
 - The lexer now recognises and lexes the unary logical operator NOT (`!`) and the binary logical operators AND (`&`) and OR (`|`).
 - The parser now recognises and parses binary logical operations (AND and NOT).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "envlang"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "unicode-segmentation",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "envlang"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 
 [lib]

--- a/src/parser/astnode.rs
+++ b/src/parser/astnode.rs
@@ -27,6 +27,14 @@ pub enum AstNode {
         parent: Option<Rc<AstNode>>,
     },
 
+    /// Unary operations are structs with two fields:
+    /// * `op`: The operator (as [`Operators`])
+    /// * `operand`: The operand (as `AstNode`)
+    UnaryOp {
+        op: Operators,
+        operand: Rc<AstNode>,
+    },
+
     /// Binary operations are structs with three fields:
     /// * `left`: Reference-counted pointer to left-hand-side operand (as `AstNode`).
     /// * `operator`: The operation (as [`Operators`]).
@@ -94,6 +102,8 @@ impl ToString for AstNode {
                     "Anonymous environment".to_string()
                 }
             },
+            AstNode::UnaryOp { op, operand }
+                => format!("{} {}", op.to_string(), operand.to_string()),
             AstNode::BinaryOp { left, operator, right }
                 => format!("{} {} {}", left.to_string(), operator.to_string(), right.to_string()),
             AstNode::Let { name, value , inherit: _ }

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -125,7 +125,7 @@ impl fmt::Display for ParserError {
             ParserError::InvalidTokenInFnCall(pos, line, valuestr) =>
                 write!(f, "Parser error at source line {}, token position {}: Expected identifier or opening function argument bracket, instead of: '{}'", line, pos, valuestr),
             ParserError::InvalidTokenInUnaryOp(pos, line, valuestr) =>
-                write!(f, "Parser error at source line {}, token position {}: Expected identifier, digit, or whitespace in unary operation, instead of: '{}'", line, pos, valuestr),
+                write!(f, "Parser error at source line {}, token position {}: Expected identifier, digit, boolean, or whitespace in unary operation, instead of: '{}'", line, pos, valuestr),
         }
     }
 }

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -49,6 +49,7 @@ pub enum ParserError {
     UnexpectedReturn(usize, usize),             // (pos, line)
     InvalidContextForIdentifier(usize, String), // (line, value)
     InvalidTokenInFnCall(usize, usize, String), // (pos, line, value)
+    InvalidTokenInUnaryOp(usize, usize, String),// (pos, line, value)
 }
 
 impl Error for ParserError {}
@@ -123,6 +124,8 @@ impl fmt::Display for ParserError {
                 write!(f, "Parser error at source line {}: Expected ParseContext::FunctionCall or ParseContext::Normal, got {}", line, valuestr),
             ParserError::InvalidTokenInFnCall(pos, line, valuestr) =>
                 write!(f, "Parser error at source line {}, token position {}: Expected identifier or opening function argument bracket, instead of: '{}'", line, pos, valuestr),
+            ParserError::InvalidTokenInUnaryOp(pos, line, valuestr) =>
+                write!(f, "Parser error at source line {}, token position {}: Expected identifier, digit, or whitespace in unary operation, instead of: '{}'", line, pos, valuestr),
         }
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -306,22 +306,21 @@ impl Parser {
                 },
                 Token::EOF => {
                     match context {
-                        ParseContext::FunctionReturn => {
-                            // Return statements can finish on EOF
+                        ParseContext::Normal => {
+                            // Normal environments can finish on EOF
                             return Ok(current_env);
                         },
-                        ParseContext::Normal if parent.is_none() => {
-                            // Global env can finish on EOF
+                        ParseContext::FunctionReturn => {
+                            // Return statements can finish on EOF
                             return Ok(current_env);
                         },
                         ParseContext::Function => {
                             // Functions cannot finish without return statements
                             return Err(ParserError::MissingReturnStatement(pos, self.line, "".into()))
                         },
-                        ParseContext::Normal
                         | ParseContext::FunctionCall
                         | ParseContext::Operation => {
-                            // Non-global env cannot finish on EOF
+                            // Operations and function calls cannot finish on EOF
                             return Err(ParserError::UnexpectedEOF(pos, self.line));
                         },
                     }
@@ -585,7 +584,7 @@ impl Parser {
                             }
                             Ok(())
                         }).expect("Safety: Will always be AstNode::Let");
-
+                        
                         return Ok(result);
                     } else {
                         return Err(ParserError::InvalidAssignmentOp(pos, self.line, token.to_string()));

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -265,6 +265,7 @@ impl Parser {
                         // We might have a unary operator on our hands
                         match op {
                             Operators::Arithmetic(ArithmeticOperators::ADD)
+                            | Operators::Logical(LogicalOperators::NOT)
                             | Operators::Arithmetic(ArithmeticOperators::SUBTRACT) => {
                                 // Valid unary operator, call parse_unary_operator
                                 let node = self.parse_unary_operator(op)?;
@@ -584,7 +585,7 @@ impl Parser {
                             }
                             Ok(())
                         }).expect("Safety: Will always be AstNode::Let");
-                        
+
                         return Ok(result);
                     } else {
                         return Err(ParserError::InvalidAssignmentOp(pos, self.line, token.to_string()));
@@ -752,6 +753,13 @@ impl Parser {
                         operand: Rc::new(AstNode::Identifier(id.clone())),
                     })
                 },
+                Token::Boolean(bool) => {
+                    // Is the operand line nasty? It feels elegant, but also nasty...
+                    return Ok(AstNode::UnaryOp {
+                        op: op.clone(),
+                        operand: Rc::new(AstNode::Boolean(match bool { Booleans::TRUE => true, Booleans::FALSE => false}))
+                    })
+                }
                 _ => {
                     return Err(ParserError::InvalidTokenInUnaryOp(pos, self.line, token.to_string()))
                 },

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -331,10 +331,8 @@ impl Parser {
 
         // Check if EOF token was consumed by one of the valid contexts
         match context {
-            ParseContext::Normal if parent.is_none() => {
-                return Ok(current_env);
-            },
-            ParseContext::FunctionReturn => {
+            ParseContext::Normal
+            | ParseContext::FunctionReturn => {
                 return Ok(current_env);
             },
             _ => Err(ParserError::UnclosedEnvironment(self.line))

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -140,6 +140,26 @@ mod tests {
     }
 
     #[test]
+    fn unary_logical_operator() {
+        let tokens = vec![
+            Token::Operator(Operators::Logical(LogicalOperators::NOT)),
+            Token::Boolean(Booleans::TRUE),
+            Token::LineTerminator,
+            Token::EOF
+        ];
+        let mut parser = Parser::new(tokens);
+        let ast = parser.parse().unwrap();
+        assert_eq!(ast, AstNode::Environment {
+            name: None,
+            bindings: vec![Rc::new(AstNode::UnaryOp {
+                op: Operators::Logical(LogicalOperators::NOT),
+                operand: Rc::new(AstNode::Boolean(true)),
+            })],
+            parent: None,
+        })
+    }
+
+    #[test]
     fn logical_operator() {
         let tokens = vec![
             Token::Boolean(Booleans::TRUE),


### PR DESCRIPTION
Solves #8, solves #13.

Add parsing of unary operators.  The changes affect the parser, especially `parse_environment` and `parse_operator`.

Also changes the behaviour of EOF token encounters: EOF tokens are now valid in all environments regardless of parentage. The context-dependency has not been changed. This also changes how the parser reacts to empty token streams, with Normal and FunctionReturn context environments validly returning the environment when no more tokens are available. Tests are passing, so other sections of the code should not have been affected.

The behavioural change to EOF token handling was necessary for unary operations nested inside binary operations (such as `let x = 5 + -3`), where the EOF token would be encountered before returning out to the global environment.

# Submission checklist

- [x] The PR is up-to-date with `main`.
- [x] The PR body text matches what has been done in the commits.
- [x] The PR does not contain any elements that are in violation of either theirs or Envlang's license.
- [x] Permission is granted to the maintainers of Envlang to use and distribute the contents of this pull request in accordance with the license of Envlang.